### PR TITLE
support for having a single service being both execution and market data gateway

### DIFF
--- a/go/execution-venues/order-router/go.sum
+++ b/go/execution-venues/order-router/go.sum
@@ -24,14 +24,6 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ettec/otp-common v1.3.1-0.20231121170433-6f1dd05c001e h1:oSJ6u7EUItXeraZhKn5pdLH7JnawKFQjib+ejRqoxOY=
-github.com/ettec/otp-common v1.3.1-0.20231121170433-6f1dd05c001e/go.mod h1:68PDrJp1ccRawgvPg0vYmSDPUi03ZCtBp4YJOJzeUjc=
-github.com/ettec/otp-common v1.4.0 h1:cjwwHtqsP9Kwr08DSN6yqhcR3HnEqhtCy795tkSRRZQ=
-github.com/ettec/otp-common v1.4.0/go.mod h1:68PDrJp1ccRawgvPg0vYmSDPUi03ZCtBp4YJOJzeUjc=
-github.com/ettec/otp-common v1.4.1-0.20231128151006-7b41d465cd74 h1:R9dxpl1H76ImUpTiUPAqEzS59zug785h9zw+fqgNgmk=
-github.com/ettec/otp-common v1.4.1-0.20231128151006-7b41d465cd74/go.mod h1:68PDrJp1ccRawgvPg0vYmSDPUi03ZCtBp4YJOJzeUjc=
-github.com/ettec/otp-common v1.4.1 h1:Im44hSM83Jy56BnurMw/ZJwtwTlnzUNlCdTFzFTn65o=
-github.com/ettec/otp-common v1.4.1/go.mod h1:68PDrJp1ccRawgvPg0vYmSDPUi03ZCtBp4YJOJzeUjc=
 github.com/ettec/otp-common v1.4.2 h1:qmgPXctGWyHAwsyz0WnSgRFvhll8OGF4sfZkSZi+1tA=
 github.com/ettec/otp-common v1.4.2/go.mod h1:68PDrJp1ccRawgvPg0vYmSDPUi03ZCtBp4YJOJzeUjc=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/go/execution-venues/order-router/service.go
+++ b/go/execution-venues/order-router/service.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"github.com/ettec/otp-common/api/executionvenue"
 	"github.com/ettec/otp-common/bootstrap"
 	"google.golang.org/grpc"
@@ -28,7 +29,10 @@ func main() {
 
 	maxConnectRetrySecs := bootstrap.GetOptionalIntEnvVar("MAX_CONNECT_RETRY_SECONDS", 60)
 
-	orderRouter, err := NewOrderRouter(maxConnectRetrySecs)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orderRouter, err := NewOrderRouter(ctx, maxConnectRetrySecs)
 	if err != nil {
 		log.Panicf("failed to create order router: %v", err)
 	}

--- a/go/market-data/market-data-service/service.go
+++ b/go/market-data/market-data-service/service.go
@@ -143,10 +143,10 @@ func main() {
 
 	namespace := "default"
 	clientSet := k8s.GetK8sClientSet(false)
-	serviceType := "market-data-gateway"
 
+	labelSelector := "servicetype in (market-data-gateway, execution-venue-and-market-data-gateway)"
 	pods, err := clientSet.CoreV1().Pods(namespace).Watch(v1.ListOptions{
-		LabelSelector: "servicetype=" + serviceType,
+		LabelSelector: labelSelector,
 	})
 
 	if err != nil {


### PR DESCRIPTION
support for having a single service being both execution venue and market data gateway.

A service labelled as 'execution-venue-and-market-data-gateway' will now be discovered by the order router and market data gateway which allows a single service to act as both service types.